### PR TITLE
Overlay: Load during Zygote only [1/2]

### DIFF
--- a/include/androidfw/AssetManager.h
+++ b/include/androidfw/AssetManager.h
@@ -236,9 +236,11 @@ public:
 private:
     struct asset_path
     {
+        asset_path() : path(""), type(kFileTypeRegular), idmap(""), isSystemOverlay(false) {}
         String8 path;
         FileType type;
         String8 idmap;
+        bool isSystemOverlay;
     };
 
     Asset* openInPathLocked(const char* fileName, AccessMode mode,


### PR DESCRIPTION
Ensure overlays are only loaded once, which will be during Zygote init

Ia5064045c77f713c58fb78adc3942f6af1abdc93
