### PR TITLE
Overlay: Load during Zygote only [2/2]

### DIFF
--- a/libs/androidfw/AssetManager.cpp
+++ b/libs/androidfw/AssetManager.cpp
@@ -607,6 +607,9 @@ FileType AssetManager::getFileType(const char* fileName)
 }
 
 bool AssetManager::appendPathToResTable(const asset_path& ap, size_t* entryIdx) const {
+    if (ap.isSystemOverlay) {
+        return true;
+    }
     Asset* ass = NULL;
     ResTable* sharedRes = NULL;
     bool shared = true;
@@ -791,6 +794,7 @@ void AssetManager::addSystemOverlays(const char* pathOverlaysList,
         oap.path = String8(buf, space - buf);
         oap.type = kFileTypeRegular;
         oap.idmap = String8(space + 1, newline - space - 1);
+        oap.isSystemOverlay = true;
 
         Asset* oass = const_cast<AssetManager*>(this)->
             openNonAssetInPathLocked("resources.arsc",


### PR DESCRIPTION
Ensure overlays are only loaded once, which will be during Zygote init

Ia5064045c77f713c58fb78adc3942f6af1abdc93
