### PR TITLE
Reintroduce lost ResTable insert of assets [1/3]

### DIFF
--- a/core/java/android/content/res/AssetManager.java
+++ b/core/java/android/content/res/AssetManager.java
@@ -632,14 +632,12 @@ public final class AssetManager implements AutoCloseable {
     public final int addOverlayPath(String idmapPath) {
         synchronized (this) {
             int res = addOverlayPathNative(idmapPath);
-            if (mStringBlocks != null) {
-                makeStringBlocks(mStringBlocks);
-            }
+            makeStringBlocks(mStringBlocks);
             return res;
         }
     }
 
-    private native final int addOverlayPathNative(String idmapPath);
+    public native final int addOverlayPathNative(String idmapPath);
 
     /**
      * Add multiple sets of assets to the asset manager at once.  See


### PR DESCRIPTION
Properly add overlay packages into the AssetManager, and insert them into the ResTable.

Ie21f227c654c98730f74a687d0e16ee2b80e747e
