### PR TITLE
Reintroduce lost ResTable insert of assets [2&3/3]

### DIFF
--- a/libs/androidfw/AssetManager.cpp
+++ b/libs/androidfw/AssetManager.cpp
@@ -298,8 +298,7 @@ bool AssetManager::addOverlayPath(const String8& packagePath, int32_t* cookie)
     *cookie = static_cast<int32_t>(mAssetPaths.size());
 
     if (mResources != NULL) {
-        size_t index = mAssetPaths.size() - 1;
-        appendPathToResTable(oap, &index);
+        appendPathToResTable(oap);
     }
 
     return true;


### PR DESCRIPTION
Properly add overlay packages into the AssetManager, and insert them into the ResTable.

Ie21f227c654c98730f74a687d0e16ee2b80e747e
